### PR TITLE
Refactored jenkins restart lock mechanism to use facts

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,18 +68,14 @@ The number of retries for the jenkins start check.
 
 The delay between the checks if the instance is started up.
 
-    jenkins_service_restart_lockfile_enabled: true
+    jenkins_service_restart_blocking_enabled: true
 
 Controls if the restart lockmechanism is active.
-Since the role may be duplicated through role dependencies this mechanism avoids multiple restart.
+Since the role may be duplicated through role dependencies this mechanism avoids multiple restart
 
-    jenkins_service_restart_lockfile_path: "/tmp/{{jenkins_service_name}}-restart.lock"
+    jenkins_service_restart_blocking_seconds: 2
 
-The path to the lockfile.
-
-    jenkins_service_restart_lockfile_age: 2000
-
-Age of the lockfile that is allowed until a new restart is triggered.
+Timespan in seconds in which the jenkins restart is blocked.
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,10 +38,7 @@ jenkins_service_check_delay: 1
 
 # Controls if the restart lockmechanism is active.
 # Since the role may be duplicated through role dependencies this mechanism avoids multiple restart
-jenkins_service_restart_lockfile_enabled: true
+jenkins_service_restart_blocking_enabled: true
 
-# The path to the lockfile
-jenkins_service_restart_lockfile_path: "/tmp/{{jenkins_service_name}}-restart.lock"
-
-# Age of the lockfile that is allowed until a new restart is triggered
-jenkins_service_restart_lockfile_age: 2000
+#Timespan in seconds in which the jenkins restart is blocked
+jenkins_service_restart_blocking_seconds: 2

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,2 +1,2 @@
 - name: wcm-io-devops.jenkins-service restart
-  include: restart_jenkins.yml
+  import_tasks: restart_jenkins.yml

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,2 +1,2 @@
 - name: wcm-io-devops.jenkins-service restart
-  import_tasks: restart_jenkins.yml
+  include_tasks: restart_jenkins.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,4 @@
-- include_tasks: start_jenkins.yml
+- include: start_jenkins.yml
   when: jenkins_service_state == 'started'
 
 - include: stop_jenkins.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,8 @@
-- include: start_jenkins.yml
+- include_tasks: start_jenkins.yml
   when: jenkins_service_state == 'started'
 
-- include: stop_jenkins.yml
+- include_tasks: stop_jenkins.yml
   when: jenkins_service_state == 'stopped'
 
-- include: restart_jenkins.yml
+- include_tasks: restart_jenkins.yml
   when: jenkins_service_state == 'restarted'

--- a/tasks/restart_jenkins.yml
+++ b/tasks/restart_jenkins.yml
@@ -1,20 +1,22 @@
-- name: "restart_jenkins : get jenkins restart lockfile age."
-  shell: "[ -f {{ jenkins_service_restart_lockfile_path }} ] && echo $(($(date +%s%N | cut -b1-13) - $(date +%s%N -r {{ jenkins_service_restart_lockfile_path }} | cut -b1-13 )))"
-  register: _jenkins_service_lockfile_age
-  failed_when: false
-  when: jenkins_service_restart_lockfile_enabled == true
+- name: "restart_jenkins : calculate milliseconds since last restart."
+  set_fact:
+    _jenkins_service_seconds_since_last_restart: "{{ lookup('pipe','date +%s') | int - _jenkins_service_last_restart_timestamp | default(0) | int }}"
 
 - block:
   - name: "restart_jenkins : include stop tasks."
     include_tasks: stop_jenkins.yml
   - name: "restart_jenkins : include start tasks."
     include_tasks: start_jenkins.yml
-  - name: "restart_jenkins : touch jenkins restart lockfile age."
-    file:
-      path: "{{ jenkins_service_restart_lockfile_path }}"
-      state: touch
-      mode: 666
-    when: jenkins_service_restart_lockfile_enabled == true
-  when: (jenkins_service_restart_lockfile_enabled == false) or
-        (_jenkins_service_lockfile_age.stdout == "") or
-        (_jenkins_service_lockfile_age.stdout|int > jenkins_service_restart_lockfile_age)
+  - name: "restart_jenkins : set last jenkins restart timestamp"
+    set_fact:
+      _jenkins_service_last_restart_timestamp: "{{ lookup('pipe','date +%s') | int }}"
+  when: (jenkins_service_restart_blocking_enabled == false) or
+        (_jenkins_service_seconds_since_last_restart | int > jenkins_service_restart_blocking_seconds | int)
+
+- name: "restart_jenkins : log restart blocked message."
+  debug:
+    msg:
+      - "jenkins restart blocked because lockfile is not old enough: {{ _jenkins_service_seconds_since_last_restart |int }}s < {{ jenkins_service_restart_blocking_seconds }}s"
+  when:
+    - jenkins_service_restart_blocking_enabled == true
+    - _jenkins_service_seconds_since_last_restart | int < jenkins_service_restart_blocking_seconds | int

--- a/tasks/restart_jenkins.yml
+++ b/tasks/restart_jenkins.yml
@@ -6,9 +6,9 @@
 
 - block:
   - name: "restart_jenkins : include stop tasks."
-    include: stop_jenkins.yml
+    include_tasks: stop_jenkins.yml
   - name: "restart_jenkins : include start tasks."
-    include: start_jenkins.yml
+    include_tasks: start_jenkins.yml
   - name: "restart_jenkins : touch jenkins restart lockfile age."
     file:
       path: "{{ jenkins_service_restart_lockfile_path }}"

--- a/tasks/restart_jenkins.yml
+++ b/tasks/restart_jenkins.yml
@@ -6,9 +6,9 @@
 
 - block:
   - name: "restart_jenkins : include stop tasks."
-    include_tasks: stop_jenkins.yml
+    include: stop_jenkins.yml
   - name: "restart_jenkins : include start tasks."
-    include_tasks: start_jenkins.yml
+    include: start_jenkins.yml
   - name: "restart_jenkins : touch jenkins restart lockfile age."
     file:
       path: "{{ jenkins_service_restart_lockfile_path }}"


### PR DESCRIPTION
Instead of writing a lockfile now an Ansible fact is used.
Deprecated `include` was refactored to use `include_tasks`.